### PR TITLE
do not ask 'Really add?' if --batch or --no-confirm is given to 'papis add'

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -412,7 +412,7 @@ def run(paths: List[str],
         for d_path in tmp_document.get_files():
             papis.utils.open_file(d_path)
 
-    if not papis.tui.utils.confirm('Really add?'):
+    if confirm and not papis.tui.utils.confirm('Really add?'):
         return
 
     logger.info(


### PR DESCRIPTION
Parameter `confirm` in `cli()` and `run()` was not taken into account before. 