### PR TITLE
New feature: open a markdown file for the current selected record with ctrl+n

### DIFF
--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -26,21 +26,23 @@ from typing import Optional
 
 def run(document: papis.document.Document,
         wait: bool = True,
-        git: bool = False) -> None:
+        git: bool = False,
+        notes: bool = False) -> None:
     database = papis.database.get()
-    info_file_path = document.get_info_file()
-    if not info_file_path:
+
+    file_path = document.get_notes_file() if notes else document.get_info_file()
+    if not file_path:
         raise Exception(papis.strings.no_folder_attached_to_document)
-    papis.utils.general_open(info_file_path, "editor", wait=wait)
+
+    papis.utils.general_open(file_path, "editor", wait=wait)
     document.load()
     database.update(document)
     if git:
         papis.git.add_and_commit_resource(
             str(document.get_main_folder()),
-            info_file_path,
+            file_path,
             "Update information for '{0}'".format(
                 papis.document.describe(document)))
-
 
 @click.command("edit")
 @click.help_option('-h', '--help')

--- a/papis/config.py
+++ b/papis/config.py
@@ -65,6 +65,7 @@ general_settings = {
     "user-agent": 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3)',
     "scripts-short-help-regex": ".*papis-short-help: *(.*)",
     "info-name": "info.yaml",
+    "notes-name": "notes.md",
     "doc-url-key-name": "doc_url",
 
     "open-mark": False,

--- a/papis/document.py
+++ b/papis/document.py
@@ -112,6 +112,7 @@ class Document(Dict[str, Any]):
 
     subfolder = ""  # type: str
     _info_file_path = ""  # type: str
+    _notes_file_path = "" # type: str
 
     def __init__(self, folder: Optional[str] = None,
                  data: Optional[Dict[str, Any]] = None):
@@ -151,6 +152,9 @@ class Document(Dict[str, Any]):
         self._info_file_path = os.path.join(
             folder,
             papis.config.getstring('info-name'))
+        self._notes_file_path = os.path.join(
+            folder,
+            papis.config.getstring('notes-name'))
         self.subfolder = (self._folder
                               .replace(os.path.expanduser("~"), "")
                               .replace("/", " "))
@@ -187,6 +191,41 @@ class Document(Dict[str, Any]):
         :rtype: str
         """
         return self._info_file_path
+
+    def get_notes_file(self) -> str:
+        """Get full path for the notes file
+        :returns: Full path for the notes file
+        :rtype: str
+        """
+
+        # Create file and put in a header if the file does not exist or is empty
+        if not os.path.exists(self._notes_file_path) or (os.path.isfile(self._notes_file_path) and os.path.getsize(self._notes_file_path) == 0):
+            with open(self._notes_file_path, 'w+') as notes:
+                title  = 'N/A'
+                ref    = 'N/A'
+                year   = 'N/A'
+                author = 'N/A'
+
+                if 'title' in self and isinstance(self['title'], str):
+                    title = self['title']
+                if 'ref' in self and isinstance(self['ref'], str):
+                    ref = self['ref']
+                if 'year' in self and isinstance(self['year'], str):
+                    year = self['year']
+                if 'author' in self and isinstance(self['author'], str):
+                    authors = self['author'].split('and')
+                    author  = authors[0].strip()
+                    if len(authors) > 1:
+                        author = author + ' et al.'
+
+                # Write header
+                notes.write('### {:s}\n'.format(title))
+                notes.write('- ref:    **{:s}**\n'.format(ref))
+                notes.write('- author: **{:s}**\n'.format(author))
+                notes.write('- year:   **{:s}**\n'.format(year))
+                notes.write('\n---')
+
+        return self._notes_file_path
 
     def get_files(self) -> List[str]:
         """Get the files linked to the document, if any.

--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -18,10 +18,11 @@ def get_default_settings() -> PapisConfigType:
 
         'move_down_key': 'down',
         'move_up_key': 'up',
-        'move_down_while_info_window_active_key': 'c-n',
-        'move_up_while_info_window_active_key': 'c-p',
+        'move_down_while_info_window_active_key': 'c-j',
+        'move_up_while_info_window_active_key': 'c-k',
         'focus_command_line_key': 'tab',
         'edit_document_key': 'c-e',
+        'edit_notes_key': 'c-n',
         'open_document_key': 'c-o',
         'show_help_key': 'f1',
         'show_info_key': 's-tab',

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -67,6 +67,10 @@ def get_keys_info() -> Dict[str, KeyInfo]:
                 'key': config.getstring('edit_document_key', section='tui'),
                 'help': 'Edit currently selected document',
             },
+            "edit_notes_key": {
+                'key': config.getstring('edit_notes_key', section='tui'),
+                'help': 'Edit notes for currently selected document',
+            },
             "open_document_key": {
                 'key': config.getstring('open_document_key', section='tui'),
                 'help': 'Open currently selected document',
@@ -210,6 +214,15 @@ def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
             run(doc)
         cmd.app.renderer.clear()
 
+    @kb.add(keys_info["edit_notes_key"]["key"],  # type: ignore
+            filter=has_focus(app.options_list.search_buffer))
+    def edit_notes(cmd: Command) -> None:
+        from papis.commands.edit import run
+        docs = cmd.app.get_selection()
+        for doc in docs:
+            run(doc, notes=True)
+        cmd.app.renderer.clear()
+
     @kb.add(keys_info["show_help_key"]["key"],  # type: ignore
             filter=~has_focus(app.help_window))
     def help(event: Event) -> None:
@@ -240,6 +253,7 @@ def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
     return ([
         Command("open", run=open, aliases=["op"]),
         Command("edit", run=edit, aliases=["e"]),
+        Command("edit", run=edit_notes, aliases=["n"]),
         Command("select", run=select, aliases=["e"]),
         Command("exit", run=exit, aliases=["quit", "q"]),
         Command("info", run=info, aliases=["i"]),

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -37,7 +37,7 @@ def general_open(
     cmd = shlex.split("{0} '{1}'".format(opener, file_name))
     LOGGER.debug("cmd:  %s", cmd)
     if wait:
-        LOGGER.debug("Waiting for process to finsih")
+        LOGGER.debug("Waiting for process to finish")
         subprocess.call(cmd)
     else:
         LOGGER.debug("Not waiting for process to finish")


### PR DESCRIPTION
- Ctrl+n opens a markdown file stored within the record folder (the same as `info.yaml`).
- The file `notes.md` includes by default a header. Example:
```md
### The MRS UAV system: Pushing the frontiers of reproducible research, real-world deployment, and education with autonomous unmanned aerial vehicles
- ref:    **baca2021mrs**
- author: **Baca, Tomas et al.**
- year:   **2021**

---
```